### PR TITLE
Add event, fix duplicate sending

### DIFF
--- a/src/Commands/SendUnreadNotifications.php
+++ b/src/Commands/SendUnreadNotifications.php
@@ -33,6 +33,11 @@ class SendUnreadNotifications extends Command
                 continue;
             }
 
+            if ($notification->last_message_at > $user->last_login_at) {
+                // User has already been notified about the latest message since their last login
+                continue;
+            }
+
             // Gather unread messages across all relevant chats
             $unreadMessages = ChatMessage::whereIn('chat_id', $userChats->pluck('chat_id'))
                 ->with('chat')

--- a/src/Events/DCodeMarkRead.php
+++ b/src/Events/DCodeMarkRead.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Dcodegroup\DCodeChat\Events;
+
+use Dcodegroup\DCodeChat\Models\Chat;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class DCodeMarkRead
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    /**
+     * Create a new event instance.
+     */
+    public function __construct(public User $user, public Chat $chat) {}
+}

--- a/src/Http/Controllers/MessagesController.php
+++ b/src/Http/Controllers/MessagesController.php
@@ -3,6 +3,7 @@
 namespace Dcodegroup\DCodeChat\Http\Controllers;
 
 use Dcodegroup\DCodeChat\Events\DCodeChatUnreadStatusChange;
+use Dcodegroup\DCodeChat\Events\DCodeMarkRead;
 use Dcodegroup\DCodeChat\Facades\ChatService;
 use Dcodegroup\DCodeChat\Models\Chat;
 use Illuminate\Http\Request;
@@ -22,6 +23,8 @@ class MessagesController
                 'has_new_messages' => false,
                 'last_read_at' => now(),
             ]);
+
+            DCodeMarkRead::dispatch(auth()->user(), $chat);
 
             DCodeChatUnreadStatusChange::dispatch(
                 auth()->user()->chats()->where('chat_id', $chat->id)->first(), // @phpstan-ignore-line

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -31,6 +31,12 @@ abstract class TestCase extends Orchestra
 
             return 'Database\\Factories\\'.class_basename($modelName).'Factory';
         });
+
+        // Publish migrations
+        $this->artisan('vendor:publish', [
+            '--tag' => 'dcode-chat-migrations',
+            '--force' => true,
+        ])->run();
     }
 
     protected function getEnvironmentSetUp($app)


### PR DESCRIPTION
## Key Points

- Add an event hook for marking chats as read
- Fix the send unread notifications command to prevent duplicates.