### PR TITLE
feature/markdown-email-view-for-unread-messages

### DIFF
--- a/resources/views/emails/unread_messages.blade.php
+++ b/resources/views/emails/unread_messages.blade.php
@@ -6,12 +6,12 @@ You have **{{ $messages->count() }} unread message{{ $messages->count() > 1 ? 's
 
 <ul>
 @foreach($messages->groupBy('chat_id') as $chatId => $msgs)
-    <li>{{ $msgs->first()->chat->users->firstWhere('user_id', $user->id)?->chat_title ?? 'Chat ID: ' . $chatId }}</li>
+<li>{{ $msgs->first()->chat->users->firstWhere('user_id', $user->id)?->chat_title ?? 'Chat ID: ' . $chatId }}</li>
 @endforeach
 </ul>
 
 <a href="{{ route('dcode-chat.chat.index') }}" style="color: #3490dc; text-decoration: none;">
-    View Messages
+View Messages
 </a>
 
 Thanks!<br>

--- a/src/Mail/UnreadMessageSummary.php
+++ b/src/Mail/UnreadMessageSummary.php
@@ -23,9 +23,8 @@ class UnreadMessageSummary extends Mailable
     public function build()
     {
         return $this->subject(config('dcode-chat.notification_email_subject', 'Unread Chat Messages'))
-            ->view(config('dcode-chat.notification_email_view', 'dcode-chat::emails.unread_messages'), [
-                'messages' => $this->messages,
-                'user' => $this->user,
-            ]);
+            ->markdown(config('dcode-chat.notification_email_view', 'dcode-chat::emails.unread_messages'))
+            ->with('messages', $this->messages)
+            ->with('user', $this->user);
     }
 }


### PR DESCRIPTION
## Kanopi

https://kanopi.live/app/ticket/56678

## Key Points

- using Markdown email view for unread messages template

## Notes

- Using `markdown` instead of `view` because only with markdown will be styles automatically converted to inline CSS styles within the HTML representations of the markdown mail messages. Check laravel [documentation](https://laravel.com/docs/12.x/mail#customizing-the-css):

<img width="1917" height="1079" alt="2025-10-02_17-20" src="https://github.com/user-attachments/assets/0e70386e-c0ea-4010-a3c9-1054b5600917" />

